### PR TITLE
Enable PHP 8.4 in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
                 php-version:
                     - "8.2"
                     - "8.3"
-#                    - "8.4"
+                    - "8.4"
 
         steps:
             - name: "Checkout"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/test.yml` file. The change re-enables PHP version 8.4 in the jobs configuration.

* `jobs:` in `.github/workflows/test.yml`: Re-enabled PHP version 8.4 in the jobs configuration.